### PR TITLE
Add LoRA fine-tuning, multi-series forecasting, and full Olist dataset

### DIFF
--- a/chronos_uco_forecast/chronos_forecast.py
+++ b/chronos_uco_forecast/chronos_forecast.py
@@ -1,13 +1,14 @@
 # Databricks notebook source
 # MAGIC %md
-# MAGIC # Chronos-2 Forecasting with Covariates
+# MAGIC # Chronos-2 Forecasting: Zero-Shot vs LoRA Fine-Tuned
 # MAGIC
-# MAGIC Reads the prepared Olist monthly time series and runs Chronos-2
-# MAGIC forecasting -- univariate and with exogenous variables.
+# MAGIC Uses per-seller monthly time series from the Olist dataset. Runs
+# MAGIC Chronos-2 zero-shot, then fine-tunes with LoRA and compares. Each
+# MAGIC approach is logged as a separate MLflow experiment.
 
 # COMMAND ----------
 
-# MAGIC %pip install chronos-forecasting matplotlib --quiet
+# MAGIC %pip install chronos-forecasting plotly "peft>=0.13,<1.0" "transformers>=4.45" --quiet
 # MAGIC %restart_python
 
 # COMMAND ----------
@@ -20,25 +21,50 @@ schema = dbutils.widgets.get("schema")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Load monthly time series
+# MAGIC ## Load per-seller monthly time series
 
 # COMMAND ----------
 
 import pandas as pd
+import numpy as np
 
-ts_df = spark.table(f"{catalog}.{schema}.olist_monthly_ts").toPandas()
-ts_df["month"] = pd.to_datetime(ts_df["month"])
-ts_df = ts_df.sort_values("month").reset_index(drop=True)
-ts_df["id"] = "olist"
+seller_df = spark.table(f"{catalog}.{schema}.olist_seller_monthly_ts").toPandas()
+seller_df["month"] = pd.to_datetime(seller_df["month"])
+seller_df = seller_df.sort_values(["seller_id", "month"]).reset_index(drop=True)
 
-ts_df = ts_df.iloc[1:-1].reset_index(drop=True)
-print(f"{len(ts_df)} months: {ts_df['month'].min():%Y-%m} to {ts_df['month'].max():%Y-%m}")
-ts_df.head()
+n_sellers = seller_df["seller_id"].nunique()
+print(f"Loaded {len(seller_df):,} rows, {n_sellers} sellers")
+seller_df.head()
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Chronos-2 univariate forecast
+# MAGIC ## Train/test split (hold out last 3 months per seller)
+
+# COMMAND ----------
+
+prediction_length = 3
+target = "revenue"
+covariate_cols = ["order_count", "avg_price", "avg_freight",
+                  "avg_delivery_days", "avg_review_score"]
+
+def split_seller(group):
+    group = group.sort_values("month")
+    n = len(group)
+    group["split"] = ["train"] * (n - prediction_length) + ["test"] * prediction_length
+    return group
+
+seller_df = seller_df.groupby("seller_id", group_keys=False).apply(split_seller)
+train_df = seller_df[seller_df["split"] == "train"].drop(columns=["split"]).reset_index(drop=True)
+test_df = seller_df[seller_df["split"] == "test"].drop(columns=["split"]).reset_index(drop=True)
+
+print(f"Train: {len(train_df):,} rows ({train_df['seller_id'].nunique()} sellers)")
+print(f"Test:  {len(test_df):,} rows ({test_df['seller_id'].nunique()} sellers)")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Load Chronos-2
 
 # COMMAND ----------
 
@@ -49,98 +75,357 @@ pipeline = Chronos2Pipeline.from_pretrained(
     device_map="cuda",
 )
 
-prediction_length = 3
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Zero-shot predictions (all sellers)
 
 # COMMAND ----------
 
-univariate_pred = pipeline.predict_df(
-    ts_df[["id", "month", "total_delivered_value"]],
+id_col = "seller_id"
+ts_col = "month"
+
+zs_univariate_pred = pipeline.predict_df(
+    train_df[[id_col, ts_col, target]],
     prediction_length=prediction_length,
     quantile_levels=[0.1, 0.5, 0.9],
-    id_column="id",
-    timestamp_column="month",
-    target="total_delivered_value",
+    id_column=id_col,
+    timestamp_column=ts_col,
+    target=target,
 )
 
-univariate_pred
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Chronos-2 forecast with covariates
-# MAGIC
-# MAGIC Exogenous features: new orders created, delivered count, avg delivery days.
-# MAGIC These are past-only covariates -- Chronos-2 learns the historical
-# MAGIC correlation between pipeline dynamics and the delivered value target.
-
-# COMMAND ----------
-
-covariate_cols = ["new_orders_created", "delivered_count", "avg_delivery_days"]
-context_cols = ["id", "month", "total_delivered_value"] + covariate_cols
-
-covariate_pred = pipeline.predict_df(
-    ts_df[context_cols],
+context_cols = [id_col, ts_col, target] + covariate_cols
+zs_covariate_pred = pipeline.predict_df(
+    train_df[context_cols],
     prediction_length=prediction_length,
     quantile_levels=[0.1, 0.5, 0.9],
-    id_column="id",
-    timestamp_column="month",
-    target="total_delivered_value",
+    id_column=id_col,
+    timestamp_column=ts_col,
+    target=target,
 )
 
-covariate_pred
+print(f"Zero-shot predictions: {len(zs_univariate_pred):,} rows")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Visualize
+# MAGIC ## Metrics helper
 
 # COMMAND ----------
 
-import matplotlib.pyplot as plt
+from sklearn.metrics import mean_absolute_error, mean_squared_error, mean_absolute_percentage_error
 
-fig, axes = plt.subplots(2, 1, figsize=(14, 8), sharex=True)
-
-for ax, pred_df, title in zip(
-    axes,
-    [univariate_pred, covariate_pred],
-    ["Univariate (target only)", "With covariates (orders, delivery speed)"],
-):
-    ts_df.plot(x="month", y="total_delivered_value", ax=ax, label="historical", color="tab:blue")
-    pred_df.plot(x="month", y="predictions", ax=ax, label="forecast", color="tab:orange")
-    ax.fill_between(
-        pred_df["month"],
-        pred_df["0.1"],
-        pred_df["0.9"],
-        alpha=0.3,
-        color="tab:orange",
-        label="80% interval",
+def calc_metrics(test_df, pred_df, target, id_col, ts_col):
+    merged = test_df[[id_col, ts_col, target]].merge(
+        pred_df[[id_col, ts_col, "predictions"]],
+        on=[id_col, ts_col], how="inner",
     )
-    ax.set_title(title)
-    ax.set_ylabel("Total delivered order value (BRL)")
-    ax.legend()
-
-plt.xlabel("Month")
-plt.tight_layout()
-plt.show()
+    merged[target] = merged[target].astype(float)
+    merged["predictions"] = merged["predictions"].astype(float)
+    actuals = merged[target].values
+    preds = merged["predictions"].values
+    mask = actuals > 0
+    return {
+        "mae": mean_absolute_error(actuals, preds),
+        "rmse": np.sqrt(mean_squared_error(actuals, preds)),
+        "mape": mean_absolute_percentage_error(actuals[mask], preds[mask]) if mask.sum() > 0 else float("nan"),
+        "n_series": merged[id_col].nunique(),
+        "n_predictions": len(merged),
+    }
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Compare univariate vs covariate forecasts
+# MAGIC ## Log zero-shot experiment
 
 # COMMAND ----------
 
-comparison = (
-    univariate_pred[["month", "predictions"]]
-    .rename(columns={"predictions": "univariate"})
-    .merge(
-        covariate_pred[["month", "predictions"]].rename(columns={"predictions": "with_covariates"}),
-        on="month",
-    )
+import mlflow
+
+zs_uni_metrics = calc_metrics(test_df, zs_univariate_pred, target, id_col, ts_col)
+zs_cov_metrics = calc_metrics(test_df, zs_covariate_pred, target, id_col, ts_col)
+
+mlflow.set_experiment(f"/Users/scott.mckean@databricks.com/chronos_olist_zero_shot")
+
+with mlflow.start_run(run_name="zero_shot") as run:
+    mlflow.log_params({
+        "model": "amazon/chronos-2",
+        "mode": "zero_shot",
+        "prediction_length": prediction_length,
+        "n_sellers": n_sellers,
+        "target": target,
+        "covariates": ", ".join(covariate_cols),
+    })
+    for prefix, m in [("univariate", zs_uni_metrics), ("covariate", zs_cov_metrics)]:
+        for k, v in m.items():
+            mlflow.log_metric(f"{prefix}_{k}", v)
+
+print("Zero-shot univariate:", {k: round(v, 4) for k, v in zs_uni_metrics.items()})
+print("Zero-shot covariate: ", {k: round(v, 4) for k, v in zs_cov_metrics.items()})
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## LoRA fine-tuning
+
+# COMMAND ----------
+
+ft_pipeline = Chronos2Pipeline.from_pretrained(
+    "amazon/chronos-2",
+    device_map="cuda",
 )
-comparison["delta_pct"] = (
-    (comparison["with_covariates"] - comparison["univariate"])
-    / comparison["univariate"]
-    * 100
-).round(2)
-display(comparison)
+
+train_records = []
+for sid, grp in train_df.groupby(id_col):
+    grp = grp.sort_values(ts_col)
+    record = {"target": grp[target].values.astype(np.float32)}
+    record["past_covariates"] = {
+        col: grp[col].values.astype(np.float32) for col in covariate_cols
+    }
+    train_records.append(record)
+
+print(f"Fine-tuning on {len(train_records)} seller time series")
+
+ft_pipeline.fit(
+    inputs=train_records,
+    prediction_length=prediction_length,
+    finetune_mode="lora",
+    num_steps=5000,
+    learning_rate=1e-5,
+    batch_size=32,
+)
+
+print("LoRA fine-tuning complete")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Fine-tuned predictions
+
+# COMMAND ----------
+
+ft_univariate_pred = ft_pipeline.predict_df(
+    train_df[[id_col, ts_col, target]],
+    prediction_length=prediction_length,
+    quantile_levels=[0.1, 0.5, 0.9],
+    id_column=id_col,
+    timestamp_column=ts_col,
+    target=target,
+)
+
+ft_covariate_pred = ft_pipeline.predict_df(
+    train_df[context_cols],
+    prediction_length=prediction_length,
+    quantile_levels=[0.1, 0.5, 0.9],
+    id_column=id_col,
+    timestamp_column=ts_col,
+    target=target,
+)
+
+print(f"Fine-tuned predictions: {len(ft_univariate_pred):,} rows")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Log fine-tuned experiment
+
+# COMMAND ----------
+
+ft_uni_metrics = calc_metrics(test_df, ft_univariate_pred, target, id_col, ts_col)
+ft_cov_metrics = calc_metrics(test_df, ft_covariate_pred, target, id_col, ts_col)
+
+mlflow.set_experiment(f"/Users/scott.mckean@databricks.com/chronos_olist_lora_finetuned")
+
+with mlflow.start_run(run_name="lora_finetuned") as ft_run:
+    mlflow.log_params({
+        "model": "amazon/chronos-2",
+        "mode": "lora_finetuned",
+        "prediction_length": prediction_length,
+        "n_sellers": n_sellers,
+        "target": target,
+        "covariates": ", ".join(covariate_cols),
+        "lora_steps": 5000,
+        "lora_lr": 1e-5,
+        "lora_batch_size": 32,
+    })
+    for prefix, m in [("univariate", ft_uni_metrics), ("covariate", ft_cov_metrics)]:
+        for k, v in m.items():
+            mlflow.log_metric(f"{prefix}_{k}", v)
+
+print("Fine-tuned univariate:", {k: round(v, 4) for k, v in ft_uni_metrics.items()})
+print("Fine-tuned covariate: ", {k: round(v, 4) for k, v in ft_cov_metrics.items()})
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Comparison summary
+
+# COMMAND ----------
+
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+
+metrics_df = pd.DataFrame([
+    {"approach": "Zero-shot univariate", **zs_uni_metrics},
+    {"approach": "Zero-shot covariate", **zs_cov_metrics},
+    {"approach": "LoRA fine-tuned univariate", **ft_uni_metrics},
+    {"approach": "LoRA fine-tuned covariate", **ft_cov_metrics},
+])
+display(metrics_df)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Metrics bar chart
+
+# COMMAND ----------
+
+metric_names = ["mae", "rmse", "mape"]
+fig = make_subplots(rows=1, cols=3, subplot_titles=["MAE", "RMSE", "MAPE"])
+
+colors = ["#1f77b4", "#ff7f0e", "#2ca02c", "#d62728"]
+for i, metric in enumerate(metric_names, start=1):
+    for j, (_, row) in enumerate(metrics_df.iterrows()):
+        fig.add_trace(go.Bar(
+            x=[row["approach"]],
+            y=[row[metric]],
+            name=row["approach"] if i == 1 else None,
+            marker_color=colors[j],
+            showlegend=(i == 1),
+            legendgroup=row["approach"],
+        ), row=1, col=i)
+
+fig.update_layout(
+    height=450, template="plotly_white", barmode="group",
+    title="Zero-Shot vs LoRA Fine-Tuned: Regression Metrics",
+)
+fig.show()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Actual vs predicted cross plot (test set, sampled sellers)
+
+# COMMAND ----------
+
+sample_sellers = test_df[id_col].unique()[:50]
+test_sample = test_df[test_df[id_col].isin(sample_sellers)]
+
+def build_cross_data(test_sample, pred_df, label):
+    m = test_sample[[id_col, ts_col, target]].merge(
+        pred_df[[id_col, ts_col, "predictions"]],
+        on=[id_col, ts_col], how="inner",
+    )
+    m["approach"] = label
+    return m
+
+cross = pd.concat([
+    build_cross_data(test_sample, zs_covariate_pred, "Zero-shot"),
+    build_cross_data(test_sample, ft_covariate_pred, "LoRA fine-tuned"),
+])
+cross[target] = cross[target].astype(float)
+cross["predictions"] = cross["predictions"].astype(float)
+
+all_vals = pd.concat([cross[target], cross["predictions"]])
+axis_min, axis_max = max(0, all_vals.min() * 0.9), all_vals.max() * 1.1
+
+cross_fig = go.Figure()
+for approach, color in [("Zero-shot", "#1f77b4"), ("LoRA fine-tuned", "#ff7f0e")]:
+    sub = cross[cross["approach"] == approach]
+    cross_fig.add_trace(go.Scatter(
+        x=sub[target], y=sub["predictions"],
+        mode="markers", name=approach,
+        marker=dict(size=6, color=color, opacity=0.6),
+    ))
+
+cross_fig.add_trace(go.Scatter(
+    x=[axis_min, axis_max], y=[axis_min, axis_max],
+    mode="lines", name="perfect", line=dict(color="grey", dash="dash"),
+))
+
+cross_fig.update_layout(
+    title="Actual vs Predicted Revenue (test set, covariate model)",
+    xaxis_title="Actual revenue (BRL)",
+    yaxis_title="Predicted revenue (BRL)",
+    template="plotly_white", height=550,
+    xaxis=dict(range=[axis_min, axis_max]),
+    yaxis=dict(range=[axis_min, axis_max]),
+)
+cross_fig.show()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Sample seller forecast visualization
+
+# COMMAND ----------
+
+top_sellers = (
+    train_df.groupby(id_col)[target].sum()
+    .nlargest(4).index.tolist()
+)
+
+fig = make_subplots(
+    rows=2, cols=2,
+    subplot_titles=[f"Seller {s[:8]}..." for s in top_sellers],
+)
+
+for idx, sid in enumerate(top_sellers):
+    row, col = idx // 2 + 1, idx % 2 + 1
+    s_train = train_df[train_df[id_col] == sid].sort_values(ts_col)
+    s_test = test_df[test_df[id_col] == sid].sort_values(ts_col)
+
+    zs_pred = zs_covariate_pred[zs_covariate_pred[id_col] == sid].sort_values(ts_col)
+    ft_pred = ft_covariate_pred[ft_covariate_pred[id_col] == sid].sort_values(ts_col)
+
+    show_legend = idx == 0
+    fig.add_trace(go.Scatter(
+        x=s_train[ts_col], y=s_train[target],
+        mode="lines", name="train", line=dict(color="#1f77b4"),
+        legendgroup="train", showlegend=show_legend,
+    ), row=row, col=col)
+
+    if len(s_test) > 0:
+        fig.add_trace(go.Scatter(
+            x=s_test[ts_col], y=s_test[target].astype(float),
+            mode="lines+markers", name="test (actual)",
+            line=dict(color="#2ca02c", dash="dash"),
+            legendgroup="test", showlegend=show_legend,
+        ), row=row, col=col)
+
+    if len(zs_pred) > 0:
+        fig.add_trace(go.Scatter(
+            x=pd.to_datetime(zs_pred[ts_col]),
+            y=zs_pred["predictions"].astype(float),
+            mode="lines+markers", name="zero-shot",
+            line=dict(color="#ff7f0e"),
+            legendgroup="zs", showlegend=show_legend,
+        ), row=row, col=col)
+
+    if len(ft_pred) > 0:
+        fig.add_trace(go.Scatter(
+            x=pd.to_datetime(ft_pred[ts_col]),
+            y=ft_pred["predictions"].astype(float),
+            mode="lines+markers", name="LoRA fine-tuned",
+            line=dict(color="#d62728"),
+            legendgroup="ft", showlegend=show_legend,
+        ), row=row, col=col)
+
+fig.update_layout(
+    height=700, template="plotly_white",
+    title="Top 4 Sellers: Zero-Shot vs LoRA Fine-Tuned Forecasts",
+)
+fig.show()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Log comparison artifacts
+
+# COMMAND ----------
+
+mlflow.set_experiment(f"/Users/scott.mckean@databricks.com/chronos_olist_lora_finetuned")
+with mlflow.start_run(run_id=ft_run.info.run_id):
+    mlflow.log_figure(cross_fig, "actual_vs_predicted.html")
+    mlflow.log_figure(fig, "top_sellers_forecast.html")
+    mlflow.log_table(metrics_df, artifact_file="metrics_comparison.json")

--- a/chronos_uco_forecast/prepare_data.py
+++ b/chronos_uco_forecast/prepare_data.py
@@ -2,8 +2,9 @@
 # MAGIC %md
 # MAGIC # Prepare Olist E-Commerce Data
 # MAGIC
-# MAGIC Downloads the Olist dataset, joins orders with payments,
-# MAGIC aggregates into a monthly time series, and saves to Delta.
+# MAGIC Downloads all 9 Olist dataset files, joins them, and produces two Delta
+# MAGIC tables: an aggregate monthly time series and a per-seller monthly time
+# MAGIC series (for multi-series forecasting and fine-tuning).
 
 # COMMAND ----------
 
@@ -26,89 +27,175 @@ spark.sql(f"CREATE SCHEMA IF NOT EXISTS {catalog}.{schema}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Download Olist dataset
+# MAGIC ## Download and load all Olist files
 
 # COMMAND ----------
 
 import kagglehub
+import pandas as pd
 
 path = kagglehub.dataset_download("olistbr/brazilian-ecommerce")
 print(f"Downloaded to: {path}")
 
-# COMMAND ----------
+files = {
+    "orders": "olist_orders_dataset.csv",
+    "items": "olist_order_items_dataset.csv",
+    "payments": "olist_order_payments_dataset.csv",
+    "products": "olist_products_dataset.csv",
+    "sellers": "olist_sellers_dataset.csv",
+    "customers": "olist_customers_dataset.csv",
+    "reviews": "olist_order_reviews_dataset.csv",
+    "categories": "product_category_name_translation.csv",
+    "geolocation": "olist_geolocation_dataset.csv",
+}
 
-# MAGIC %md
-# MAGIC ## Load and join orders with payments
-
-# COMMAND ----------
-
-import pandas as pd
-
-orders_pd = pd.read_csv(os.path.join(path, "olist_orders_dataset.csv"))
-payments_pd = pd.read_csv(os.path.join(path, "olist_order_payments_dataset.csv"))
-
-order_values = payments_pd.groupby("order_id")["payment_value"].sum().reset_index()
-order_values.columns = ["order_id", "order_value"]
-
-orders_pd = orders_pd.merge(order_values, on="order_id", how="inner")
-for col in ["order_purchase_timestamp", "order_delivered_customer_date"]:
-    orders_pd[col] = pd.to_datetime(orders_pd[col])
-
-orders = spark.createDataFrame(orders_pd)
-print(f"Orders: {orders.count()}")
+dfs = {}
+for name, fname in files.items():
+    fpath = os.path.join(path, fname)
+    dfs[name] = pd.read_csv(fpath)
+    print(f"{name}: {len(dfs[name]):,} rows, {list(dfs[name].columns)}")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Aggregate into monthly time series
+# MAGIC ## Join into a single denormalized orders table
 
 # COMMAND ----------
 
-from pyspark.sql import functions as F
+orders = dfs["orders"].copy()
+for col in ["order_purchase_timestamp", "order_delivered_customer_date",
+            "order_approved_at", "order_estimated_delivery_date"]:
+    orders[col] = pd.to_datetime(orders[col], errors="coerce")
 
-monthly_delivered = (
-    orders
-    .filter(F.col("order_delivered_customer_date").isNotNull())
-    .withColumn("month", F.date_trunc("month", F.col("order_delivered_customer_date")))
-    .groupBy("month")
+items = dfs["items"].copy()
+items["item_total"] = items["price"] + items["freight_value"]
+
+payment_totals = dfs["payments"].groupby("order_id")["payment_value"].sum().reset_index()
+payment_totals.columns = ["order_id", "payment_value"]
+
+review_scores = dfs["reviews"].groupby("order_id")["review_score"].mean().reset_index()
+
+products = dfs["products"][["product_id", "product_category_name"]].copy()
+products = products.merge(
+    dfs["categories"], on="product_category_name", how="left"
+)
+
+enriched = (
+    items
+    .merge(orders[["order_id", "customer_id", "order_status",
+                    "order_purchase_timestamp", "order_delivered_customer_date",
+                    "order_estimated_delivery_date"]],
+           on="order_id", how="inner")
+    .merge(payment_totals, on="order_id", how="left")
+    .merge(review_scores, on="order_id", how="left")
+    .merge(products[["product_id", "product_category_name_english"]], on="product_id", how="left")
+    .merge(dfs["sellers"][["seller_id", "seller_state"]], on="seller_id", how="left")
+    .merge(dfs["customers"][["customer_id", "customer_state"]], on="customer_id", how="left")
+)
+
+enriched = enriched[enriched["order_status"] == "delivered"].copy()
+enriched["delivery_days"] = (
+    enriched["order_delivered_customer_date"] - enriched["order_purchase_timestamp"]
+).dt.total_seconds() / 86400
+
+print(f"Enriched delivered items: {len(enriched):,}")
+enriched.head()
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Aggregate: monthly time series (single series)
+
+# COMMAND ----------
+
+enriched["month"] = enriched["order_purchase_timestamp"].dt.to_period("M").dt.to_timestamp()
+
+agg_monthly = (
+    enriched.groupby("month")
     .agg(
-        F.sum("order_value").alias("total_delivered_value"),
-        F.count("*").alias("delivered_count"),
-        F.avg(
-            F.datediff(
-                F.col("order_delivered_customer_date"),
-                F.col("order_purchase_timestamp"),
-            )
-        ).alias("avg_delivery_days"),
+        total_delivered_value=("item_total", "sum"),
+        new_orders_created=("order_id", "nunique"),
+        delivered_count=("order_id", "count"),
+        avg_delivery_days=("delivery_days", "mean"),
+        avg_review_score=("review_score", "mean"),
+        n_unique_sellers=("seller_id", "nunique"),
+        n_unique_products=("product_id", "nunique"),
+        avg_freight=("freight_value", "mean"),
     )
-    .orderBy("month")
+    .reset_index()
+    .sort_values("month")
 )
 
-monthly_created = (
-    orders
-    .withColumn("month", F.date_trunc("month", F.col("order_purchase_timestamp")))
-    .groupBy("month")
-    .agg(F.count("*").alias("new_orders_created"))
-    .orderBy("month")
-)
-
-monthly_ts = (
-    monthly_delivered
-    .join(monthly_created, on="month", how="outer")
-    .fillna(0)
-    .orderBy("month")
-)
-
-display(monthly_ts)
+print(f"Aggregate monthly: {len(agg_monthly)} months")
+display(spark.createDataFrame(agg_monthly))
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Save to Delta
+# MAGIC ## Per-seller monthly time series
 
 # COMMAND ----------
 
-monthly_ts.createOrReplaceTempView("monthly_ts_temp")
-spark.sql(f"CREATE OR REPLACE TABLE {catalog}.{schema}.olist_monthly_ts AS SELECT * FROM monthly_ts_temp")
+seller_monthly_raw = (
+    enriched.groupby(["seller_id", "month"])
+    .agg(
+        revenue=("item_total", "sum"),
+        order_count=("order_id", "nunique"),
+        item_count=("order_id", "count"),
+        avg_price=("price", "mean"),
+        avg_freight=("freight_value", "mean"),
+        avg_delivery_days=("delivery_days", "mean"),
+        avg_review_score=("review_score", "mean"),
+        n_unique_products=("product_id", "nunique"),
+        n_unique_customers=("customer_id", "nunique"),
+    )
+    .reset_index()
+    .sort_values(["seller_id", "month"])
+)
 
-print(f"Saved to {catalog}.{schema}.olist_monthly_ts")
+all_months = pd.date_range(
+    enriched["month"].min(), enriched["month"].max(), freq="MS"
+)
+
+def fill_monthly_grid(grp):
+    grp = grp.set_index("month").reindex(all_months).rename_axis("month").reset_index()
+    grp["seller_id"] = grp["seller_id"].ffill().bfill()
+    fill_zero = ["revenue", "order_count", "item_count", "n_unique_products", "n_unique_customers"]
+    grp[fill_zero] = grp[fill_zero].fillna(0)
+    fill_cols = ["avg_price", "avg_freight", "avg_delivery_days", "avg_review_score"]
+    grp[fill_cols] = grp[fill_cols].ffill().bfill()
+    return grp
+
+seller_monthly = (
+    seller_monthly_raw
+    .groupby("seller_id", group_keys=False)
+    .apply(fill_monthly_grid)
+    .sort_values(["seller_id", "month"])
+    .reset_index(drop=True)
+)
+
+active_months = seller_monthly_raw.groupby("seller_id")["month"].count()
+min_active_months = 8
+active_sellers = active_months[active_months >= min_active_months].index
+seller_monthly_filtered = seller_monthly[seller_monthly["seller_id"].isin(active_sellers)].copy()
+
+print(f"Total sellers: {enriched['seller_id'].nunique()}")
+print(f"Sellers with >= {min_active_months} active months: {len(active_sellers)}")
+print(f"Per-seller monthly rows (with gap-fill): {len(seller_monthly_filtered):,}")
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Save both tables to Delta
+
+# COMMAND ----------
+
+agg_sdf = spark.createDataFrame(agg_monthly)
+agg_sdf.createOrReplaceTempView("agg_monthly_temp")
+spark.sql(f"CREATE OR REPLACE TABLE {catalog}.{schema}.olist_monthly_ts AS SELECT * FROM agg_monthly_temp")
+print(f"Saved {catalog}.{schema}.olist_monthly_ts ({len(agg_monthly)} rows)")
+
+seller_sdf = spark.createDataFrame(seller_monthly_filtered)
+seller_sdf.createOrReplaceTempView("seller_monthly_temp")
+spark.sql(f"CREATE OR REPLACE TABLE {catalog}.{schema}.olist_seller_monthly_ts AS SELECT * FROM seller_monthly_temp")
+print(f"Saved {catalog}.{schema}.olist_seller_monthly_ts ({len(seller_monthly_filtered):,} rows)")

--- a/resources/chronos_forecast.job.yml
+++ b/resources/chronos_forecast.job.yml
@@ -26,6 +26,4 @@ resources:
             base_parameters:
               catalog: "shm"
               schema: "ts"
-          environment_key: default
-          compute:
-            hardware_accelerator: GPU_1xA10
+          existing_cluster_id: "0413-033721-y3w2m2kb"


### PR DESCRIPTION
## Summary
- Updated prepare_data.py to use all 9 Olist dataset files, producing per-seller monthly time series with gap-filled months
- Added LoRA fine-tuning (5000 steps) with covariates alongside zero-shot baseline
- Switched all visualizations to plotly, added actual vs predicted cross plots
- Separate MLflow experiments for zero-shot and fine-tuned runs with regression metrics (MAE, RMSE, MAPE)

## Test plan
- [x] prepare_data task runs and produces both aggregate and per-seller Delta tables
- [x] chronos_forecast runs zero-shot + LoRA fine-tuning + comparison visualizations
- [x] MLflow experiments logged with metrics and plotly artifacts